### PR TITLE
scpaste-org

### DIFF
--- a/scpaste.el
+++ b/scpaste.el
@@ -87,6 +87,7 @@
 
 ;;; Code:
 
+(require 'org)
 (require 'url)
 (require 'htmlize)
 
@@ -140,13 +141,13 @@ Corresponds to ssh’s `-i` option Example: \"~/.ssh/id.pub\"")
 
 
 ;;;###autoload
-(defun scpaste (original-name)
+(defun do-scpaste (original-name exporter)
   "Paste the current buffer via `scp' to `scpaste-http-destination'.
 If ORIGINAL-NAME is an empty string, then the buffer name is used
 for the file name."
   (interactive "MName (defaults to buffer name): ")
   (let* ((b (generate-new-buffer (generate-new-buffer-name "b")))
-         (hb (htmlize-buffer))
+         (hb (funcall exporter))
          (name (replace-regexp-in-string "[/\\%*:|\"<>  ]+" "_"
                                          (if (equal "" original-name)
                                              (buffer-name)
@@ -203,6 +204,16 @@ for the file name."
           (progn
             (pop-to-buffer error-buffer)
             (help-mode-setup)))))))
+
+;;;###autoload
+(defun scpaste (original-name)
+  (interactive "MName (defaults to buffer name): ")
+  (do-scpaste original-name 'htmlize-buffer))
+
+;;;###autoload
+(defun scpaste-org (original-name)
+  (interactive "MName (defaults to buffer name): ")
+  (do-scpaste original-name 'org-html-export-as-html))
 
 ;;;###autoload
 (defun scpaste-region (name)

--- a/scpaste.el
+++ b/scpaste.el
@@ -147,11 +147,11 @@ If ORIGINAL-NAME is an empty string, then the buffer name is used
 for the file name."
   (interactive "MName (defaults to buffer name): ")
   (let* ((b (generate-new-buffer (generate-new-buffer-name "b")))
-         (hb (funcall exporter))
          (name (replace-regexp-in-string "[/\\%*:|\"<>  ]+" "_"
                                          (if (equal "" original-name)
                                              (buffer-name)
                                            original-name)))
+         (hb (funcall exporter))
          (full-url (concat scpaste-http-destination
                            "/" (url-hexify-string name) ".html"))
          (scp-destination (concat scpaste-scp-destination

--- a/scpaste.el
+++ b/scpaste.el
@@ -139,7 +139,6 @@ Corresponds to ssh’s `-i` option Example: \"~/.ssh/id.pub\"")
           " using <a href='http://p.hagelb.org'>scpaste</a> at %s. "
           (cadr (current-time-zone)) ". (<a href='%s'>original</a>)</p>"))
 
-
 ;;;###autoload
 (defun do-scpaste (original-name exporter)
   "Paste the current buffer via `scp' to `scpaste-http-destination'.
@@ -147,6 +146,7 @@ If ORIGINAL-NAME is an empty string, then the buffer name is used
 for the file name."
   (interactive "MName (defaults to buffer name): ")
   (let* ((b (generate-new-buffer (generate-new-buffer-name "b")))
+         (original-buffer (current-buffer))
          (name (replace-regexp-in-string "[/\\%*:|\"<>  ]+" "_"
                                          (if (equal "" original-name)
                                              (buffer-name)
@@ -163,6 +163,7 @@ for the file name."
 
     ;; Save the files (while adding a footer to html file)
     (save-excursion
+      (switch-to-buffer original-buffer)
       (copy-to-buffer b (point-min) (point-max))
       (switch-to-buffer b)
       (write-file tmp-file)

--- a/scpaste.el
+++ b/scpaste.el
@@ -163,7 +163,7 @@ BUFFER may be either a buffer or its name (a string)."
               ;; Ignore error, in particular,
               ;; "Attempt to delete the sole visible or iconified frame".
               (condition-case nil (delete-window win) (error nil))))))
-    (when (called-interactively-p)
+    (when (called-interactively-p 'any)
       (error "Cannot kill buffer.  Not a live buffer: `%s'" buffer))))
 
 
@@ -195,7 +195,7 @@ for the file name."
       (copy-to-buffer b (point-min) (point-max))
       (switch-to-buffer b)
       (write-file tmp-file)
-      (kill-buffer-and-its-window b)
+      (kill-buffer-and-its-windows b)
       (switch-to-buffer hb)
       (goto-char (point-min))
       (search-forward "</body>\n</html>")
@@ -203,7 +203,7 @@ for the file name."
                       (current-time-string)
                       (substring full-url 0 -5)))
       (write-file tmp-hfile)
-      (kill-buffer-and-its-window hb))
+      (kill-buffer-and-its-windows hb))
 
     (let* ((identity (if scpaste-scp-pubkey
                          (concat "-i " scpaste-scp-pubkey) ""))


### PR DESCRIPTION
Use org-html-export-as-html to provide a new scpaste-org function.

No idea what you will think of this (and I don't know much elisp so apologies if this is a crap implementation), but I've found it extremely useful to be able to export my org files to html and scp them up.

An alternative approach might be to provide a scpaste-exporter variable, and I could then write my scpaste-org function outside of the core lib by doing something like:

```lisp
(defun scpaste-org (name)
  (interactive "MName: ")
  (let ()
    (setq scpaste-exporter 'org-html-export-as-html)
    (scpaste name)
    ((setq scpaste-exporter 'htmlize-buffer)))
```